### PR TITLE
GET /microdust/map API

### DIFF
--- a/src/main/java/com/seeme/controller/MicrodustController.java
+++ b/src/main/java/com/seeme/controller/MicrodustController.java
@@ -70,4 +70,13 @@ public class MicrodustController {
 		}
 	}
 
+	@GetMapping("/map")
+	public ResponseEntity<Object> getMap() {
+		try {
+			return ResponseEntity.ok().body(microdustService.getMap());
+		} catch (Exception e) {
+			e.printStackTrace();
+			return ResponseEntity.internalServerError().body("internal server error");
+		}
+	}
 }

--- a/src/main/java/com/seeme/domain/microdust/Microdust.java
+++ b/src/main/java/com/seeme/domain/microdust/Microdust.java
@@ -8,7 +8,8 @@ import lombok.ToString;
 @Getter
 @ToString
 public class Microdust {
-	private final int pm10Value;
-	private final int pm25Value;
-	private final int pmGrade;
+	private final String stationName;
+	private final String pm10Value;
+	private final String pm25Value;
+	private final String pm10Grade;
 }

--- a/src/main/java/com/seeme/domain/microdust/MicrodustMapResDto.java
+++ b/src/main/java/com/seeme/domain/microdust/MicrodustMapResDto.java
@@ -1,0 +1,15 @@
+package com.seeme.domain.microdust;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MicrodustMapResDto {
+	private final String stationName;
+	private final Double lat;
+	private final Double lon;
+	private final String pm10;
+	private final String pm25;
+	private final String grade;
+}

--- a/src/main/java/com/seeme/domain/microdust/MicrodustStation.java
+++ b/src/main/java/com/seeme/domain/microdust/MicrodustStation.java
@@ -1,0 +1,25 @@
+package com.seeme.domain.microdust;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "station")
+public class MicrodustStation {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
+
+	private String name;
+
+	private Double x;
+
+	private Double y;
+}

--- a/src/main/java/com/seeme/domain/microdust/MicrodustStationRepository.java
+++ b/src/main/java/com/seeme/domain/microdust/MicrodustStationRepository.java
@@ -1,0 +1,6 @@
+package com.seeme.domain.microdust;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface MicrodustStationRepository extends CrudRepository<MicrodustStation, Long> {
+}

--- a/src/main/java/com/seeme/service/MicrodustService.java
+++ b/src/main/java/com/seeme/service/MicrodustService.java
@@ -95,8 +95,8 @@ public class MicrodustService {
 			MicrodustStation station = map.get(microdust.getStationName());
 			microdustMapList.add(MicrodustMapResDto.builder()
 				.stationName(microdust.getStationName())
-				.lat(station.getY())
-				.lon(station.getX())
+				.lat(station.getX())
+				.lon(station.getY())
 				.pm10(microdust.getPm10Value())
 				.pm25(microdust.getPm25Value())
 				.grade(microdust.getPm10Grade())

--- a/src/main/java/com/seeme/service/MicrodustService.java
+++ b/src/main/java/com/seeme/service/MicrodustService.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @AllArgsConstructor
@@ -19,17 +21,18 @@ public class MicrodustService {
 
 	private final LocationApi locationApi;
 	private final MicrodustOpenApi microdustOpenApi;
+	private final MicrodustStationRepository microdustStationRepository;
 
 	public MicrodustResDto getMain(List<String> measuringStationList, String address) throws IOException, ParseException {
 		Microdust microdust = microdustOpenApi.getMainApi(measuringStationList);
 		System.out.println(microdust.toString()); // remove
 		return MicrodustResDto.builder()
 			.address(address)
-			.pm10(microdust.getPm10Value())
-			.pm25(microdust.getPm25Value())
-			.grade(MicrodustUtil.getGrade(microdust.getPmGrade()))
+			.pm10(Integer.parseInt(microdust.getPm10Value()))
+			.pm25(Integer.parseInt(microdust.getPm25Value()))
+			.grade(MicrodustUtil.getGrade(microdust.getPm10Grade()))
 			.gradeIcon(MicrodustUtil.GRADE_ICON)
-			.desc(MicrodustUtil.getDesc(microdust.getPmGrade()))
+			.desc(MicrodustUtil.getDesc(microdust.getPm10Grade()))
 			.build();
 	}
 
@@ -50,7 +53,7 @@ public class MicrodustService {
 	public List<MicrodustDayResDto> getDay(double lat, double lon) throws IOException, ParseException {
 		List<MicrodustDayResDto> microdustDayResDtoList = new ArrayList<>();
 
-		for (MicrodustDayDto microdustDayDto : microdustOpenApi.getDayApi(lat, lon)){
+		for (MicrodustDayDto microdustDayDto : microdustOpenApi.getDayApi(lat, lon)) {
 			microdustDayResDtoList.add(MicrodustDayResDto.builder()
 				.dustAm(10)
 				.dustPm(10)
@@ -81,5 +84,25 @@ public class MicrodustService {
 
 	public TMAddress getTMAddress(String location) throws IOException {
 		return locationApi.getTMAddress(location);
+	}
+
+	public List<MicrodustMapResDto> getMap() throws IOException {
+		Map<String, MicrodustStation> map = new HashMap<>();
+		microdustStationRepository.findAll().forEach(station -> map.put(station.getName(), station));
+
+		List<MicrodustMapResDto> microdustMapList = new ArrayList<>();
+		for (Microdust microdust : microdustOpenApi.getMap()) {
+			MicrodustStation station = map.get(microdust.getStationName());
+			microdustMapList.add(MicrodustMapResDto.builder()
+				.stationName(microdust.getStationName())
+				.lat(station.getY())
+				.lon(station.getX())
+				.pm10(microdust.getPm10Value())
+				.pm25(microdust.getPm25Value())
+				.grade(microdust.getPm10Grade())
+				.build());
+		}
+
+		return microdustMapList;
 	}
 }

--- a/src/main/java/com/seeme/service/api/ApiConfig.java
+++ b/src/main/java/com/seeme/service/api/ApiConfig.java
@@ -27,4 +27,6 @@ public class ApiConfig {
 	private String TMAddressKey;
 	private String microdustDayUrl;
 	private String microdustDayKey;
+	private String microdustMapUrl;
+	private String microdustMapKey;
 }

--- a/src/main/java/com/seeme/util/MicrodustUtil.java
+++ b/src/main/java/com/seeme/util/MicrodustUtil.java
@@ -19,9 +19,10 @@ public class MicrodustUtil {
 	public static final String APP_ID = "appid";
 	public static final String LAT = "lat";
 	public static final String LON = "lon";
+	public static final String SIDO_NAME = "sidoName";
 
-	public static String getGrade(int pm10Grade1h) {
-		switch (pm10Grade1h) {
+	public static String getGrade(String pm10Grade1h) {
+		switch (Integer.parseInt(pm10Grade1h)) {
 			case 1:
 				return "좋음";
 			case 2:
@@ -35,8 +36,8 @@ public class MicrodustUtil {
 		}
 	}
 
-	public static String getDesc(int pm10Grade1h) {
-		switch (pm10Grade1h) {
+	public static String getDesc(String pm10Grade1h) {
+		switch (Integer.parseInt(pm10Grade1h)) {
 			case 1:
 				return "야외 활동을 즐겨보세요 !";
 			case 2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,5 +19,11 @@ microdust-main-key:
 microdust-station-url: http://apis.data.go.kr/B552584/MsrstnInfoInqireSvc/getNearbyMsrstnList
 specific-address-url: https://dapi.kakao.com/v2/local/geo/coord2regioncode.json
 specific-address-key:
+TM-address-url: http://apis.data.go.kr/B552584/MsrstnInfoInqireSvc/getTMStdrCrdnt
+TM-address-key:
 microdust-day-url: http://api.openweathermap.org/data/2.5/air_pollution/forecast
 microdust-day-key:
+microdust-time-url: https://api.tomorrow.io/v4/timelines
+microdust-time-key:
+microdust-map-url: http://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty
+microdust-map-key:


### PR DESCRIPTION
현재 미세먼지 및 초미세먼지 값으로 지도에 핀을 꼽을 수 있는 정보를 반환하는 API를 구현하였습니다. [API DOC #](https://ssk0967.gitbook.io/seeme-api/microdust/microdust/microdust_city)

1. [한국환경공단 api 1](https://www.data.go.kr/tcs/dss/selectApiDataDetailView.do?publicDataPk=15073877)를 활용하여 현재 존재하는 모든 측정소의 정보 (측정소 이름, 위도, 경도)를 데이터베이스에 저장해두었습니다.
2. [한국환경공단 api 2](https://www.data.go.kr/tcs/dss/selectApiDataDetailView.do?publicDataPk=15073861)를 활용하여 전국의 현재 미세먼지/초미세먼지 측정값을 측정소의 정보와 엮어 원하는 출력방식으로 정보를 리턴합니다.